### PR TITLE
Store Psk For Subscriber

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 tokio = { version = "0.2.22", features = ["full"] }
 anyhow = { version = "1.0.38", default-features = false }
-iota-streams = { git = "https://github.com/iotaledger/streams", branch = "chrysalis-2" }
+iota-streams = { git = "https://github.com/iotaledger/streams", branch = "v1.1.0" }
 rand = "0.7.3"
 hyper = "0.13"
 json = "0.12.4"

--- a/config.json
+++ b/config.json
@@ -3,5 +3,6 @@
   "mwm": 5,
   "local_pow": true,
   "api_port": 8080,
-  "seed": null
+  "seed": null,
+  "pre_shared_key": "SubscriberPreSharedKey"
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,9 @@ async fn main() -> Result<()> {
         seed = config["seed"].as_str().unwrap().to_string()
     }
 
-    let mwm = config["mwm"].as_u64().unwrap() as u8;
     let node = config["node"].as_str().unwrap();
-    let local_pow = config["local_pow"].as_bool().unwrap();
     let port = config["api_port"].as_u64().unwrap() as u16;
+    let psk = config["pre_shared_key"].as_str().unwrap();
 
 
     let annotation_store = Arc::new(Mutex::new(AnnotationStore::new()));
@@ -32,7 +31,7 @@ async fn main() -> Result<()> {
     println!("Making Streams channel...");
     println!("node = {}", config["node"]);
     println!("seed = {}", seed.as_str());
-    let author = Arc::new(Mutex::new(ChannelAuthor::new(seed.as_str(), mwm, local_pow, node).unwrap()));
+    let author = Arc::new(Mutex::new(ChannelAuthor::new(seed.as_str(), node, psk).unwrap()));
     let channel_address = author.lock().unwrap().get_announcement_id().unwrap();
     println!("\nChannel Address - {}:{}\n", channel_address.0, channel_address.1);
 


### PR DESCRIPTION
This pr shows how to add a pre shared key as a base for using external subscribers for message retrieval. 